### PR TITLE
Update gerber_generator.py

### DIFF
--- a/gerber_generator.py
+++ b/gerber_generator.py
@@ -6,10 +6,17 @@ class GerberGenerator:
     def __init__(self, args):
         self.args = args    
 
+    def read(self, filename):
+        # temporary replacement for pcb-tools-extension python 3 compatibility issue for gerberex.read()
+        with open(filename, 'r') as f:
+            data = f.read()
+        load_gerber = gerberex.loads(data, filename)
+        return load_gerber
+
     def generate_gerber(self, filename):
 
         # Generate the top layer gerber file
-        tl_dxf = gerberex.read(filename.split(".")[0] + '_top.dxf')
+        tl_dxf = self.read(filename.split(".")[0] + '_top.dxf')
         tl_ctx = gerberex.GerberComposition()
         tl_dxf.draw_mode = tl_dxf.DM_FILL
         tl_ctx.merge(tl_dxf)
@@ -17,7 +24,7 @@ class GerberGenerator:
         print("[*] Top layer gerber file generated: " + filename.split(".")[0] + "_top.gtl")
 
         # Generate the substrate gerber file
-        s_dxf = gerberex.read(filename.split(".")[0] + '_substrate.dxf')
+        s_dxf = self.read(filename.split(".")[0] + '_substrate.dxf')
         s_ctx = gerberex.GerberComposition()
         s_ctx.merge(s_dxf)
         s_ctx.dump(filename.split(".")[0] + '_substrate.gml')


### PR DESCRIPTION
patch on gerber generation. pcb-tools-extension .read() func doesn't work with recent Python 3 versions